### PR TITLE
Add Doubling ¢ section

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -1117,7 +1117,7 @@
     \subsection*{Lose ¢}
     Move the specified number of ¢ from your ¢ pool into the game’s ¢ pool. If you don’t have the specified number of ¢, you just lose as many ¢ as possible.
     \subsection*{Pay}
-    To pay ¢, you move the specified number of ¢ from your ¢ pool to the game’s ¢ pool. If you don’t have enough ¢ to pay, you can’t pay. To pay <3, you lose that many <3. If you don’t have enough <3 to pay, you can’t pay. This doesn’t change your max HP\heart.
+    To pay ¢, you move the specified number of ¢ from your ¢ pool to the game’s ¢ pool. If you don’t have enough ¢ to pay, you can’t pay. To pay \heart, you lose that many \heart. If you don’t have enough \heart\ to pay, you can’t pay. This doesn’t change your max HP\heart.
     \subsection*{Play}
     Move a loot card from your hand to the stack.
     \subsection*{Prevent}
@@ -1131,9 +1131,9 @@
     \subsection*{Round}
     A round lasts from the start of a player’s turn until the start of their next one, with each other player having had a turn in between.
     \subsection*{Steal}
-    A target gives you a specified object or resource, chosen by you.
+    A target \textbf{gives} you a specified object or resource, chosen by you.
     \subsection*{Swap}
-    Two players simultaneously give each other a specified object or resource.
+    Two players simultaneously \textbf{give} each other a specified object or resource.
     \subsection*{Trinket}
     When a trinket resolves, it becomes an item under the control of the player who played it (see \textbf{Keyworded Abilities}\footnote{page~\pageref{keyworded}}).
 

--- a/main.tex
+++ b/main.tex
@@ -141,7 +141,7 @@
 
     If you are playing with \textbf{bonus souls}, shuffle them, and pick 3 at random. Those 3 are the \textbf{active bonus souls} for the game and are placed face-up next to the play area.
 
-    Deal a random character card to each player, as well as that character’s starting item card. Characters start the game \textbf{deactivated} (turned sideways). Starting items start the game \textbf{charged} (turned upright). Abilities that trigger at the start of the game trigger, for example Eden’s triggered ability. No one has \textbf{priority} here (see The Stack\footnote{page~\pageref{stack}}) and so these abilities will all resolve instantly.
+    Deal a random character card to each player, as well as that character’s starting item card. Characters start the game \textbf{deactivated} (turned sideways). Starting items start the game \textbf{charged} (turned upright). Abilities that trigger at the start of the game trigger, for example Eden’s triggered ability. No one has \textbf{priority} here (see \textbf{The Stack}\footnote{page~\pageref{stack}}) and so these abilities will all resolve instantly.
 
     Deal 3 loot cards and 3¢ to each player. Each player puts the loot cards in their \textbf{hand}.
 
@@ -153,7 +153,7 @@
     \cardfigv{assets/treasure.png}
     Treasure cards are found in the treasure deck. Whilst \textbf{in play} (see \textbf{Game Zones}\footnote{page~\pageref{zones}}), a treasure card is an object referred to as an \textbf{item}. This means items are either controlled by a player or in the shop.
   
-    Players will acquire items throughout the game. Items have a wide variety of abilities that can range from modifying gameplay to interacting with other players and monsters (see Abilities\footnote{page~\pageref{abilities}}). Players place any items they control face up in front of them.
+    Players will acquire items throughout the game. Items have a wide variety of abilities that can range from modifying gameplay to interacting with other players and monsters (see \textbf{Abilities}\footnote{page~\pageref{abilities}}). Players place any items they control face up in front of them.
   
     Any time a card instructs a player to \textbf{gain treasure}, they gain that many cards from the top of the treasure deck, putting them into play under their control.
   

--- a/main.tex
+++ b/main.tex
@@ -511,6 +511,8 @@
     \textbf{Die} is a related action. It means that the game \textbf{destroys/kills} a specified object in play. An object that is destroyed/killed \textbf{dies}.
     \section{Discard}
     \textbf{Discard} is an action done to loot cards in hand. To discard, you move the specified number of loot cards from your hand into the loot discard.
+    \section{Doubling ¢}
+    If an ability instructs you to double the number of ¢ a player has, that player gains x¢, where x is the number of ¢ they have.
     \section{Each}
     Abilities that affect all players or objects of a certain type use the terminology of ‘each’ – e.g. “Each player loots 1.” or “Reroll each item you control.” Some abilities may also specify a more specific group, for example “Each living player” or “Each non-eternal item”.
 


### PR DESCRIPTION
Add Doubling ¢ section.

This section can be found under the Specific Mechanics [Doubling ¢ section](https://foursouls.com/rules/extended-rulebook/#doubling_%C2%A2).